### PR TITLE
Implemented sampling levels from trajectories

### DIFF
--- a/torchmdexp/datasets/levelsfactory.py
+++ b/torchmdexp/datasets/levelsfactory.py
@@ -3,12 +3,15 @@ from torchmdexp.datasets.utils import get_chains
 from torchmdexp.samplers.utils import get_native_coords
 from .proteins import ProteinDataset
 import os
-import yaml
+import torch
 import numpy as np
+from torchmdexp.metrics.ligand_rmsd import ligand_rmsd
 
 class LevelsFactory:
     
-    def __init__(self, dataset_path, levels_dir, num_levels=None, out_dir = None):
+    def __init__(self, dataset_path, levels_dir = None, levels_from = 'traj', num_levels = None, out_dir = None):
+
+        assert levels_from in ('traj', 'files'), "levels_from can be 'traj' or 'files'"
 
         with open(dataset_path, 'r') as f:
             dataset_names = f.readlines()
@@ -16,9 +19,16 @@ class LevelsFactory:
         
         self.dataset = {}
         self.names = []
-    
-        avail_levels = [s for s in os.listdir(levels_dir) if not s.startswith('.')]
-        self.num_levels = min(num_levels, len(avail_levels))
+        
+        if levels_from == 'traj':
+            print('Getting levels from trajectory')
+            self.num_levels = num_levels
+            avail_levels = ['level_0']
+            
+        elif levels_from == 'files':
+            print('Getting levels from files')
+            avail_levels = [s for s in os.listdir(levels_dir) if not s.startswith('.')]
+            self.num_levels = min(num_levels, len(avail_levels))
         
         for level, level_name in zip(range(self.num_levels), avail_levels):
             
@@ -47,15 +57,88 @@ class LevelsFactory:
                     else:
                         params['ground_truths'].append(self.dataset[0]['ground_truths'][idx])
                     params['lengths'].append(mol.numAtoms)
-            
-            
+        
             self.dataset[level] = params
         
         if out_dir:
             np.save(os.path.join(out_dir, 'dataset.npy'), self.dataset)
 
+    def trajSample(self, kwargs):
+        from torchmd.forcefields.forcefield import ForceField
+        from torchmd.parameters import Parameters
+        from torchmd.forces import Forces
+        from torchmd.systems import System
+        from torchmd.integrator import Integrator, maxwell_boltzmann
         
+        for lvl in range(1, self.num_levels):
+                self.dataset[lvl] = {'names' : [],
+                                    'molecules': [],
+                                    'ground_truths': [],
+                                    'lengths': []}
+
+        nreplicas = 4
+        output_period = 60
+        nsteps = output_period * int(self.num_levels * 1.5)
+        precision = torch.double
+
+        for mol_idx, mol_safe in enumerate(self.dataset[0]['molecules']):
+            mol = mol_safe.copy()
+            print(f"Sampling levels from {mol.viewname}.")
+            
+            # Create forces
+            if kwargs.ff_type == 'file':
+                ff = ForceField.create(mol, kwargs.forcefield)        
+            elif kwargs.ff_type == 'full_pseudo_receptor':
+                ff = ForceField.create(mol, os.path.join(kwargs.log_dir, 'forcefield.yaml'))
+            else:
+                raise ValueError('ff_type should be ("file" | "full_pseudo_receptor") but ',
+                                'got ' + kwargs.ff_type + ' instead')
         
+            sim_params = Parameters(ff, mol, terms=kwargs.forceterms, device=kwargs.device)
+            
+            forces = Forces(parameters=sim_params,
+                            terms=kwargs.forceterms,
+                            cutoff=kwargs.cutoff,
+                            external=None,
+                            rfa=kwargs.rfa,
+                            switch_dist=kwargs.switch_dist,
+                            exclusions=kwargs.exclusions)
+            
+            # Create the system and the integrator
+            sys = System(mol.numAtoms, precision=precision, device=kwargs.device, nreplicas=nreplicas)
+            sys.set_box(np.tile(mol.box, nreplicas))
+            sys.set_positions(mol.coords)
+            sys.set_velocities(maxwell_boltzmann(forces.par.masses, T=kwargs.temperature, replicas=nreplicas))
+
+            integrator = Integrator(sys, forces, 
+                                    kwargs.timestep, 
+                                    gamma=kwargs.langevin_gamma, 
+                                    device=kwargs.device, T=kwargs.temperature * 2)
+            
+            nsamples = nreplicas * nsteps // output_period
+            samples = torch.zeros(nsamples, len(integrator.systems.pos[0]), 3, 
+                                  device = "cpu", dtype = precision)
+            
+            for i in range(nsteps // output_period):
+                _ = integrator.step(output_period)
+                samples[i*nreplicas:(i+1)*nreplicas] = integrator.systems.pos.to('cpu')[:]
+                
+            difficulty = [(idx, ligand_rmsd(sample, self.dataset[0]['ground_truths'][mol_idx], mol)) 
+                          for idx, sample in enumerate(samples)]
+            difficulty.sort(key = lambda x: x[1])
+            
+            name = self.dataset[0]['names'][mol_idx]
+            name = ''.join([l for l in name][:-1])
+            
+            for lvl, (idx, _) in enumerate(difficulty[:(self.num_levels-1)*nreplicas:nreplicas], start = 1):
+                # import ipdb; ipdb.set_trace()
+                mol.coords = np.moveaxis(samples[idx, np.newaxis].numpy(), 0, 2)
+                self.dataset[lvl]['molecules'].append(mol.copy())
+                
+                self.dataset[lvl]['names'].append(f'{name}{lvl}')
+                self.dataset[lvl]['ground_truths'].append(self.dataset[0]['ground_truths'][mol_idx])
+                self.dataset[lvl]['lengths'].append(self.dataset[0]['lengths'][mol_idx])
+
     def level(self, level):
         import copy
         
@@ -73,8 +156,8 @@ class LevelsFactory:
     
     def get_mols(self):
         mols = []
-        for level in range(self.num_levels):
-            mols += self.dataset[level]['molecules']
+        for key in self.dataset:
+            mols += self.dataset[key]['molecules']
         return mols
     
     def get_names(self):

--- a/torchmdexp/utils/parsing.py
+++ b/torchmdexp/utils/parsing.py
@@ -111,6 +111,7 @@ def get_args():
 
     # dataset specific
     parser.add_argument('--num-levels', default=None, help='How many levels to use including the 0th level')
+    parser.add_argument('--levels-from', default='traj', choices=['traj', 'files'], help='Get the levels from files or from a trajectory of level 0')
     parser.add_argument('--levels_dir', default=None, help='Directory with levels folders. Which contains different levels of difficulty')
     parser.add_argument('--thresh-lvlup', default=5.0, type=float, help='Loss value to get before leveling up')
     parser.add_argument('--dataset',  default=None, help='File with the dataset')


### PR DESCRIPTION
Now `levels_factory` can use a trajectory to sample the levels for the training. The used structures are saved on the output directory, but this is managed from the train script.